### PR TITLE
Adiciona controle para documentos já depositados

### DIFF
--- a/doi_request/controller.py
+++ b/doi_request/controller.py
@@ -1,6 +1,9 @@
 import logging
 
-from tasks.celery import registry_dispatcher_document
+from tasks.celery import (
+    registry_dispatcher_document,
+    registry_dispatcher_document_skip_deposited,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -8,13 +11,19 @@ logger = logging.getLogger(__name__)
 
 class Depositor(object):
 
-    def deposit_by_pids(self, pids_list):
+    def deposit_by_pids(self, pids_list, skip_deposited=False):
         """
         Receive a list of pids and collection to registry their dois.
         scl
         """
+        if skip_deposited:
+            register_document = registry_dispatcher_document_skip_deposited
+        else:
+            register_document = registry_dispatcher_document
+
         for item in pids_list:
             collection, code = item.split('_')
-            registry_dispatcher_document.delay(code, collection)
+            register_document.delay(code,
+                                    collection)
             logger.info('enqueued deposit for "%s"', item)
 

--- a/processing/exportDOI.py
+++ b/processing/exportDOI.py
@@ -47,7 +47,7 @@ class ExportDOI(object):
 
                 code = '_'.join([document.collection, document.code])
                 logger.info('collecting document for deposit: %s', code)
-                self._depositor.deposit_by_pids([code])
+                self._depositor.deposit_by_pids([code], skip_deposited=True)
                 count += 1
 
         logger.info('finished collecting documents. total: %d', count)


### PR DESCRIPTION
A funcionalidade foi dividida em 2 tasks para driblar uma limitação do
Celery que causava erro com o uso de keyword-arguments.

#### O que esse PR faz?
Previne que execuções sucessivas do utilitário `exportdoi` resultem em múltiplos depósitos dos mesmos documentos no Crossref. 

A abordagem foi adicionar o argumento `skip_deposited` no método `Depositor.deposit_by_pids`, com o valor padrão igual a `False`. O utilitário `exportDOI`, ao invocar o método, passa o argumento `skip_deposited=True`, evitando assim o comportamento indesejado.

A funcionalidade de redepósito fornecida pela interface gráfica de usuário continua operando da mesma maneira que antes.

#### Onde a revisão poderia começar?
Sugiro no módulo `doi_request/controller.py`

#### Como este poderia ser testado manualmente?
Será necessário subir uma instância local, usando as mesmas configurações de uma instância de homologação ou produção.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A